### PR TITLE
Printf reorg / add Project.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.jl.cov
 *.jl.mem
+Manifest.toml
 deps/IntelRDFPMathLib*
 deps/installed_vers
 deps/libbid*.*

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,19 @@
+name = "DecFP"
+uuid = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"
+version = "0.4.8"
+
+[deps]
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+
+[compat]
+julia = "≥ 0.7.0"
+
+[extras]
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Printf"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-BinaryProvider
-SpecialFunctions

--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -1,7 +1,7 @@
 
 module DecFP
 
-import SpecialFunctions
+import Printf, SpecialFunctions
 
 export Dec32, Dec64, Dec128, @d_str, @d32_str, @d64_str, @d128_str, exponent10, ldexp10
 
@@ -283,7 +283,7 @@ for w in (32,64,128)
             return
         end
 
-        function Base.Printf.fix_dec(x::$BID, n::Int, digits)
+        function Printf.Printf.fix_dec(x::$BID, n::Int, digits)
             if n > length(digits) - 1
                 n = length(digits) - 1
             end
@@ -324,7 +324,7 @@ for w in (32,64,128)
             return Int32(len), Int32(pt), neg
         end
 
-        function Base.Printf.ini_dec(x::$BID, n::Int, digits)
+        function Printf.Printf.ini_dec(x::$BID, n::Int, digits)
             if n > length(digits) - 1
                 n = length(digits) - 1
             end
@@ -353,8 +353,8 @@ for w in (32,64,128)
         end
 
         # compatibility with julia#30373
-        Base.Printf.fix_dec(x::$BID, n::Int) = Base.Printf.fix_dec(x, n, getdigitsbuf())
-        Base.Printf.ini_dec(x::$BID, n::Int) = Base.Printf.ini_dec(x, n, getdigitsbuf())
+        Printf.Printf.fix_dec(x::$BID, n::Int) = Printf.Printf.fix_dec(x, n, getdigitsbuf())
+        Printf.Printf.ini_dec(x::$BID, n::Int) = Printf.Printf.ini_dec(x, n, getdigitsbuf())
 
         Base.fma(x::$BID, y::$BID, z::$BID) = nox(ccall(($(bidsym(w,"fma")), libbid), $BID, ($BID,$BID,$BID), x, y, z))
         Base.muladd(x::$BID, y::$BID, z::$BID) = fma(x,y,z) # faster than x+y*z


### PR DESCRIPTION
`Base.Printf` was removed with https://github.com/JuliaLang/julia/pull/33313.

Julia nightly now requires Project.toml https://github.com/JuliaLang/Pkg.jl/pull/1356.

Fixes https://github.com/JuliaMath/DecFP.jl/issues/98