### PR TITLE
Correct floatmin()

### DIFF
--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -515,9 +515,12 @@ for T in (Dec32, Dec64, Dec128)
         Base.typemax(::Type{$T}) = $(_parse(T, "+inf"))
         Base.typemin(::Type{$T}) = $(_parse(T, "-inf"))
         Base.floatmax(::Type{$T}) = $(_prevfloat(_parse(T, "+inf")))
-        Base.floatmin(::Type{$T}) = $(_nextfloat(zero(T)))
     end
 end
+
+Base.floatmin(::Type{Dec32}) = reinterpret(Dec32, 0x03000001) # Dec32("1.0e-95")
+Base.floatmin(::Type{Dec64}) = reinterpret(Dec64, 0x01e0000000000001) # Dec64("1.0e-383")
+Base.floatmin(::Type{Dec128}) = reinterpret(Dec128, 0x00420000000000000000000000000001) # Dec128("1.0e-6143")
 
 Base.maxintfloat(::Type{Dec32}) = reinterpret(Dec32, 0x36000001) # Dec32("1e7")
 Base.maxintfloat(::Type{Dec64}) = reinterpret(Dec64, 0x33c0000000000001) # Dec64("1e16")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,20 +12,17 @@ for T in (Dec32, Dec64, Dec128)
         @test d32"3.2" * d32"4.5" == d32"14.4"
         @test eps(Dec32) == parse(Dec32, "1e-6")
         @test floatmax(Dec32) == parse(Dec32, "+9999999E+90")
-        @test floatmin(Dec32) == parse(Dec32, "+1E-101")
         @test bswap(Dec32(1.5)) == reinterpret(Dec32, bswap(reinterpret(UInt32, Dec32(1.5))))
     elseif T == Dec64
         @test d"3.2" * d"4.5" == d"14.4"
         @test d64"3.2" * d64"4.5" == d64"14.4"
         @test eps(Dec64) == parse(Dec64, "1e-15")
         @test floatmax(Dec64) == parse(Dec64, "+9999999999999999E+369")
-        @test floatmin(Dec64) == parse(Dec64, "+1E-398")
         @test bswap(Dec64(1.5)) == reinterpret(Dec64, bswap(reinterpret(UInt64, Dec64(1.5))))
     else
         @test d128"3.2" * d128"4.5" == d128"14.4"
         @test eps(Dec128) == parse(Dec128, "1e-33")
         @test floatmax(Dec128) == parse(Dec128, "+9999999999999999999999999999999999E+6111")
-        @test floatmin(Dec128) == parse(Dec128, "+1E-6176")
         @test bswap(Dec128(1.5)) == reinterpret(Dec128, bswap(reinterpret(UInt128, Dec128(1.5))))
     end
 
@@ -113,6 +110,11 @@ for T in (Dec32, Dec64, Dec128)
     @test prevfloat(xd)::T == xd - eps(T)
     @test nextfloat(T(1.5e10)) == 1.5e10 + eps(T(1.5e10))
     @test prevfloat(T(1.5e10)) == 1.5e10 - eps(T(1.5e10))
+
+    @test floatmin(T) > 0
+    @test !issubnormal(floatmin(T))
+    @test issubnormal(prevfloat(floatmin(T)))
+    @test floatmin(T) == nextfloat(zero(T)) / eps(T)
 
     @test eps(maxintfloat(T) - 1) == 1
     @test eps(maxintfloat(T)) == 10


### PR DESCRIPTION
Correct `floatmin()` to conform to the Julia definition:

Return the smallest positive normal number representable by the floating-point type T.

Fixes #82.