### PR TITLE
Add logabsgamma

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-SpecialFunctions = "0.7, 0.8, 0.9"
+SpecialFunctions = "0.8, 0.9, 0.10"
 julia = "1.3"
 
 [extras]

--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -404,7 +404,15 @@ for w in (32,64,128)
     @eval Base.:-(x::$BID) = @xchk(ccall(($(bidsym(w,"negate")), libbid), $BID, ($BID,), x), DomainError, x, mask=INVALID)
     @eval Base.round(x::$BID) = @xchk(ccall(($(bidsym(w,"nearbyint")), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
 
-    @eval SpecialFunctions.lgamma(x::$BID) = @xchk(ccall(($(bidsym(w,:lgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
+    @eval begin
+        function SpecialFunctions.logabsgamma(x::$BID)
+            isequal(modf(x)[1], -zero(x)) && return typemax(x), one(Int32)
+            signgam = signbit(x) && mod(x, 2) > 1 ? -one(Int32) : one(Int32)
+            y = @xchk(ccall(($(bidsym(w,:lgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
+            return y, signgam
+        end
+    end
+
     @eval SpecialFunctions.gamma(x::$BID) = @xchk(ccall(($(bidsym(w,:tgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
 
     for (r,c) in ((RoundingMode{:Nearest},"round_integral_nearest_even"), (RoundingMode{:NearestTiesAway},"round_integral_nearest_away"), (RoundingMode{:ToZero},"round_integral_zero"), (RoundingMode{:Up},"round_integral_positive"), (RoundingMode{:Down},"round_integral_negative"))

--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -404,13 +404,11 @@ for w in (32,64,128)
     @eval Base.:-(x::$BID) = @xchk(ccall(($(bidsym(w,"negate")), libbid), $BID, ($BID,), x), DomainError, x, mask=INVALID)
     @eval Base.round(x::$BID) = @xchk(ccall(($(bidsym(w,"nearbyint")), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
 
-    @eval begin
-        function SpecialFunctions.logabsgamma(x::$BID)
-            isequal(modf(x)[1], -zero(x)) && return typemax(x), one(Int32)
-            signgam = signbit(x) && mod(x, 2) > 1 ? -one(Int32) : one(Int32)
-            y = @xchk(ccall(($(bidsym(w,:lgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
-            return y, signgam
-        end
+    @eval function SpecialFunctions.logabsgamma(x::$BID)
+        isequal(modf(x)[1], -zero(x)) && return typemax(x), one(Int32)
+        signgam = signbit(x) && mod(x, 2) > 1 ? -one(Int32) : one(Int32)
+        y = @xchk(ccall(($(bidsym(w,:lgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
+        return y, signgam
     end
 
     @eval SpecialFunctions.gamma(x::$BID) = @xchk(ccall(($(bidsym(w,:tgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,13 +152,26 @@ for T in (Dec32, Dec64, Dec128)
         end
     end
 
-    for f in (exp,log,sin,cos,tan,asin,acos,atan,sinh,cosh,tanh,asinh,acosh,atanh,log1p,expm1,log10,log2,exp2,exp10,lgamma,sqrt,cbrt)
+    for f in (exp,log,sin,cos,tan,asin,acos,atan,sinh,cosh,tanh,asinh,acosh,atanh,log1p,expm1,log10,log2,exp2,exp10,sqrt,cbrt)
         v = f == acosh ? x : z
         @test f(T(v)) ≈ f(v)
     end
 
     # issue #47
     @test exp10(T(0)) == T(1)
+
+    for x = -3.0:0.25:3.0
+        @test all(logabsgamma(T(x)) .≈ logabsgamma(x))
+    end
+    for x in (NaN, -Inf, -0.0, Inf)
+        @test isequal(logabsgamma(T(x)), logabsgamma(x))
+    end
+
+    @test_throws DomainError gamma(T(-1))
+    @test isnan(gamma(T(NaN)))
+    for x in (-1.5, -0.5, -0.0, 0.0, 0.5, 1.0, 1.5, 2.0, Inf)
+        @test gamma(T(x)) ≈ gamma(x)
+    end
 
     for c in (π, e, γ, catalan, φ)
         @test T(c) ≈ Float64(c)


### PR DESCRIPTION
Fixes #100 `lgamma` gets a deprecation warning from SpecialFunctions.

```
julia> using DecFP

julia> using SpecialFunctions

julia> lgamma(d64"4.0")
┌ Warning: `lgamma(x::Real)` is deprecated, use `(logabsgamma(x))[1]` instead.
│   caller = top-level scope at REPL[3]:1
└ @ Core REPL[3]:1
1.791759469228055

julia> logabsgamma(d64"4.0")
(1.791759469228055, 1)

julia> logabsgamma(d64"4.0")[1]
1.791759469228055
```