### PR TITLE
Implement rand()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.10"
 [deps]
 DecFP_jll = "47200ebd-12ce-5be5-abb7-8e082af23329"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]

--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -3,7 +3,7 @@ module DecFP
 
 using DecFP_jll
 
-import Printf, SpecialFunctions
+import Printf, Random, SpecialFunctions
 
 export Dec32, Dec64, Dec128, @d_str, @d32_str, @d64_str, @d128_str, exponent10, ldexp10
 
@@ -496,6 +496,8 @@ for w in (32,64,128)
     end
 
     @eval SpecialFunctions.gamma(x::$BID) = @xchk(ccall(($(bidsym(w,:tgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
+
+    @eval Random.rand(r::Random.AbstractRNG, ::Random.SamplerTrivial{Random.CloseOpen01{$BID}}) =  $BID(1, rand(zero($Ti):$Ti(maxintfloat($BID)) - one($Ti)), -(9 * $w ÷ 32 - 2))
 
     for (r,c) in ((RoundingMode{:Nearest},"round_integral_nearest_even"), (RoundingMode{:NearestTiesAway},"round_integral_nearest_away"), (RoundingMode{:ToZero},"round_integral_zero"), (RoundingMode{:Up},"round_integral_positive"), (RoundingMode{:Down},"round_integral_negative"))
         @eval Base.round(x::$BID, ::$r) = @xchk(ccall(($(bidsym(w,c)), libbid), $BID, ($BID,Ref{Cuint}), x, RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)

--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -497,7 +497,7 @@ for w in (32,64,128)
 
     @eval SpecialFunctions.gamma(x::$BID) = @xchk(ccall(($(bidsym(w,:tgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
 
-    @eval Random.rand(r::Random.AbstractRNG, ::Random.SamplerTrivial{Random.CloseOpen01{$BID}}) =  $BID(1, rand(zero($Ti):$Ti(maxintfloat($BID)) - one($Ti)), -(9 * $w ÷ 32 - 2))
+    @eval Random.rand(r::Random.AbstractRNG, ::Random.SamplerTrivial{Random.CloseOpen01{$BID}}) =  $BID(1, rand(r, zero($Ti):$Ti(maxintfloat($BID)) - one($Ti)), -(9 * $w ÷ 32 - 2))
 
     for (r,c) in ((RoundingMode{:Nearest},"round_integral_nearest_even"), (RoundingMode{:NearestTiesAway},"round_integral_nearest_away"), (RoundingMode{:ToZero},"round_integral_zero"), (RoundingMode{:Up},"round_integral_positive"), (RoundingMode{:Down},"round_integral_negative"))
         @eval Base.round(x::$BID, ::$r) = @xchk(ccall(($(bidsym(w,c)), libbid), $BID, ($BID,Ref{Cuint}), x, RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,10 +257,10 @@ for T in (Dec32, Dec64, Dec128)
     A = Vector{T}(undef, 16)
     rand!(A)
     @test all(0 .<= A .< 1)
+    # test uniform distribution
     # array version
     counts = hist(rand(T, 2000), 4)
     @test minimum(counts) > 300 # should fail with proba < 1e-26
-    # test uniform distribution
     # scalar version
     counts = hist([rand(T) for i in 1:2000], 4)
     @test minimum(counts) > 300

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,6 +260,7 @@ for T in (Dec32, Dec64, Dec128)
     # array version
     counts = hist(rand(T, 2000), 4)
     @test minimum(counts) > 300 # should fail with proba < 1e-26
+    # test uniform distribution
     # scalar version
     counts = hist([rand(T) for i in 1:2000], 4)
     @test minimum(counts) > 300


### PR DESCRIPTION
Implements `rand()` but not `randn()` or `randexp()`.  We should implement the Ziggurat Method for `randn()` and `randexp()`.  Most of the tests including `hist()` were copied directly from stdlib/Random/test.  Partially addresses issue #80.