### PR TITLE
Export sigexp

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,6 +183,16 @@ for T in (Dec32, Dec64, Dec128)
     x,y,z = 1.5, -3.25, 0.0625 # exactly represented in binary
     xd = T(x); yd = T(y); zd = T(z)
 
+    @test_throws DomainError sigexp(T(NaN))
+    @test_throws DomainError sigexp(T(Inf))
+    @test_throws DomainError sigexp(T(-Inf))
+    @test sigexp(T(0)) == (1, 0, 0)
+    @test sigexp(T("-0")) == (-1, 0, 0)
+    @test sigexp(T(1)) == (1, 1, 0)
+    @test sigexp(T(-1)) == (-1, 1, 0)
+    @test sigexp(T(-1.25)) == (-1, 125, -2)
+    @test sigexp(maxintfloat(T) - 1) == (1, Int128(maxintfloat(T) - 1), 0)
+
     @test fma(xd,yd,zd)::T == muladd(xd,yd,zd)::T == xd*yd+zd == fma(x,y,z)
 
     @test one(T)::T == 1


### PR DESCRIPTION
I opted to have this return `Integers` instead of floating point values.  Most uses of this function are probably looking for integers and this avoids the inefficiency of converting an integer to floating point which the user immediately converts back to integer.  One consequence of returning integers is that this function throws a `DomainError` for `Inf` or `NaN` inputs.  The user would need to check for and handle these values anyway; this just encourages the check before calling `sigexp`.
```
julia> sigexp(d64"-1.25")
(-1, 125, -2)

julia> sigexp(d64"1")
(1, 1, 0)

julia> sigexp(d64"1.0")
(1, 10, -1)
```
Fixes #130 
cc @quinnj 