### PR TITLE
Update return type for logabsgamma

### DIFF
--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -523,8 +523,8 @@ for w in (32,64,128)
     @eval Base.round(x::$BID) = @xchk(ccall(($(bidsym(w,"nearbyint")), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
 
     @eval function SpecialFunctions.logabsgamma(x::$BID)
-        isequal(modf(x)[1], -zero(x)) && return typemax(x), one(Int)
-        signgam = signbit(x) && mod(x, 2) > 1 ? -one(Int) : one(Int)
+        isequal(modf(x)[1], -zero(x)) && return typemax(x), 1
+        signgam = signbit(x) && mod(x, 2) > 1 ? -1 : 1
         y = @xchk(ccall(($(bidsym(w,:lgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
         return y, signgam
     end

--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -523,8 +523,8 @@ for w in (32,64,128)
     @eval Base.round(x::$BID) = @xchk(ccall(($(bidsym(w,"nearbyint")), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
 
     @eval function SpecialFunctions.logabsgamma(x::$BID)
-        isequal(modf(x)[1], -zero(x)) && return typemax(x), one(Int32)
-        signgam = signbit(x) && mod(x, 2) > 1 ? -one(Int32) : one(Int32)
+        isequal(modf(x)[1], -zero(x)) && return typemax(x), one(Int)
+        signgam = signbit(x) && mod(x, 2) > 1 ? -one(Int) : one(Int)
         y = @xchk(ccall(($(bidsym(w,:lgamma)), libbid), $BID, ($BID,Cuint,Ref{Cuint}), x, roundingmode[Threads.threadid()], RefArray(flags, Threads.threadid())), DomainError, x, mask=INVALID)
         return y, signgam
     end


### PR DESCRIPTION
Change return type of `logabsgamma` to conform with SpecialFunctions v1.6.  Closes #145.