### PR TITLE
Remove ARM 32-bit jobs from drone

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,24 +1,27 @@
-local Pipeline(os, arch, version) = {
+local Pipeline(os, arch, version, alpine=false) = {
     kind: "pipeline",
-    name: os+" - "+arch+" - Julia "+version,
+    name: os+" - "+arch+" - Julia "+version+(if alpine then " (Alpine)" else ""),
     platform: {
-	os: os,
-	arch: arch
+        os: os,
+        arch: arch
     },
     steps: [
-	{
-	    name: "build",
-	    image: "julia:"+version,
-	    commands: [
-		"julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true); using Pkg; Pkg.build(); Pkg.test(coverage=true)'"
-	    ]
-	}
-    ]
+        {
+            name: "Run tests",
+            image: "julia:"+version+(if alpine then "-alpine" else ""),
+            commands: [
+                "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true)'",
+                "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.build()'",
+                "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test(coverage=true)'"
+            ]
+        }
+    ],
+    trigger: {
+        branch: ["master"]
+    }
 };
 
 [
-    Pipeline("linux", "arm",   "1.3"),
-    Pipeline("linux", "arm",   "1.4"),
     Pipeline("linux", "arm64", "1.3"),
-    Pipeline("linux", "arm64", "1.4")
+    Pipeline("linux", "arm64", "1.7.2")
 ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,33 +1,5 @@
 ---
 kind: pipeline
-name: linux - arm - Julia 1.3
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
-- name: build
-  image: julia:1.3
-  commands:
-  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true); using Pkg; Pkg.build(); Pkg.test(coverage=true)'"
-
----
-kind: pipeline
-name: linux - arm - Julia 1.7.2
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
-- name: build
-  image: julia:1.7.2
-  commands:
-  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true); using Pkg; Pkg.build(); Pkg.test(coverage=true)'"
-
----
-kind: pipeline
 name: linux - arm64 - Julia 1.3
 
 platform:
@@ -35,10 +7,16 @@ platform:
   arch: arm64
 
 steps:
-- name: build
+- name: Run tests
   image: julia:1.3
   commands:
-  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true); using Pkg; Pkg.build(); Pkg.test(coverage=true)'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true)'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.build()'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test(coverage=true)'"
+
+trigger:
+  branch:
+  - master
 
 ---
 kind: pipeline
@@ -49,9 +27,15 @@ platform:
   arch: arm64
 
 steps:
-- name: build
+- name: Run tests
   image: julia:1.7.2
   commands:
-  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true); using Pkg; Pkg.build(); Pkg.test(coverage=true)'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true)'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.build()'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test(coverage=true)'"
+
+trigger:
+  branch:
+  - master
 
 ...


### PR DESCRIPTION
32-bit systems are now tested with GitHub actions, and the armv7l job for Julia
v1.7 is stalling for unrelated reasons.

Also, run Drone CI only on `master` branch, to avoid duplicate jobs in pull
requests.