### PR TITLE
Optimize component part construction

### DIFF
--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -143,7 +143,7 @@ for w in (32,64,128)
             s = q
             e += 1
         end
-        while e > bemax && s < _int_maxintfloat($BID) / 10
+        while e > bemax && s < _int_maxintfloat($BID) ÷ $Ti(10)
             s *= $Ti(10)
             e -= 1
         end

--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -137,13 +137,13 @@ for w in (32,64,128)
         sb = signbit(sign) ? one($Ti) << ($w - 1) : zero($Ti)
         e = exponent + bias
         s = $Ti(abs(significand))
-        while s >= $Ti(maxintfloat($BID))
+        while s >= _int_maxintfloat($BID)
             q, r = divrem(s, $Ti(10))
             r != 0 && throw(InexactError(Symbol($BID), $BID, (sign, significand, exponent)))
             s = q
             e += 1
         end
-        while e > bemax && s < $Ti(maxintfloat($BID)) / 10
+        while e > bemax && s < _int_maxintfloat($BID) / 10
             s *= $Ti(10)
             e -= 1
         end
@@ -760,6 +760,9 @@ Base.floatmin(::Type{Dec128}) = reinterpret(Dec128, 0x00420000000000000000000000
 Base.maxintfloat(::Type{Dec32}) = reinterpret(Dec32, 0x36000001) # Dec32("1e7")
 Base.maxintfloat(::Type{Dec64}) = reinterpret(Dec64, 0x33c0000000000001) # Dec64("1e16")
 Base.maxintfloat(::Type{Dec128}) = reinterpret(Dec128, 0x30840000000000000000000000000001) # Dec128("1e34")
+_int_maxintfloat(::Type{Dec32}) = 0x00989680
+_int_maxintfloat(::Type{Dec64}) = 0x002386f26fc10000
+_int_maxintfloat(::Type{Dec128}) = 0x0001ed09bead87c0378d8e6400000000
 
 Base.convert(::Type{F}, x::Union{Int8,UInt8,Int16,UInt16}) where {F<:DecimalFloatingPoint} = F(Int32(x))
 Base.convert(::Type{F}, x::Integer) where {F<:DecimalFloatingPoint} = F(string(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -503,3 +503,8 @@ end
     @test precision(Dec64, base=100) == 8
     @test precision(d32"1.2345", base=10) == 7
 end
+
+# PR #155
+@test DecFP._int_maxintfloat(Dec32) === UInt32(maxintfloat(Dec32))
+@test DecFP._int_maxintfloat(Dec64) === UInt64(maxintfloat(Dec64))
+@test DecFP._int_maxintfloat(Dec128) === UInt128(maxintfloat(Dec128))


### PR DESCRIPTION
Component part construction performs some redundant conversions on constants.

The conversions are more costly than they look, as the decimal to integer path range checks against type ranges on the integer types, which in turn performs conversions of these to the decimal type. For `Dec128/UInt128` this is particularly bad as the integer to decimal conversion falls back to conversion via strings.

Fixed by precomputing integer constants.

Simple example benchmark in the form of
```Julia
@btime T($(Ref(123))[], $(Ref(-8))[])
```

| T | before | after |
| --- | --- | --- |
| Dec32 | 10.701 ns (0 allocations: 0 bytes) | 4.200 ns (0 allocations: 0 bytes) |
| Dec64 | 11.912 ns (0 allocations: 0 bytes)  | 3.810 ns (0 allocations: 0 bytes) |
| Dec128 | 394.069 ns (6 allocations: 288 bytes) | 6.510 ns (0 allocations: 0 bytes) |

