### PR TITLE
Fix Irrational and BigFloat comparisons

### DIFF
--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -226,6 +226,8 @@ for w in (32,64,128)
     ```
     """ $BID
 
+    @eval $BID(x::AbstractIrrational, r::RoundingMode) = $BID(string(BigFloat(x, precision=256)), r)
+
     # fix method ambiguities:
     @eval $BID(x::Rational{T}) where {T} = convert($BID, x)
 
@@ -758,18 +760,18 @@ function Base.:(==)(dec::DecimalFloatingPoint, rat::Rational)
     end
 end
 
-Base.:(==)(dec::T, flt::Union{Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec == T(flt, RoundUp) == T(flt, RoundDown)
-Base.:>(dec::T, flt::Union{Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec > T(flt, RoundDown)
-Base.:<(dec::T, flt::Union{Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec < T(flt, RoundUp)
-Base.:(>=)(dec::T, flt::Union{Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec >= T(flt, RoundUp)
-Base.:(<=)(dec::T, flt::Union{Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec <= T(flt, RoundDown)
+Base.:(==)(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec == T(num, RoundUp) == T(num, RoundDown)
+Base.:>(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}) where {T<:DecimalFloatingPoint} = dec > T(num, RoundDown)
+Base.:<(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}) where {T<:DecimalFloatingPoint} = dec < T(num, RoundUp)
+Base.:(>=)(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec >= T(num, RoundUp)
+Base.:(<=)(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec <= T(num, RoundDown)
 
 # canonicalize comparison order:
-Base.:(==)(flt::Union{Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec == flt
-Base.:>(flt::Union{Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec < flt
-Base.:<(flt::Union{Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec > flt
-Base.:(>=)(flt::Union{Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec <= flt
-Base.:(<=)(flt::Union{Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec >= flt
+Base.:(==)(num::Union{BigFloat,Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec == num
+Base.:>(num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}, dec::T) where {T<:DecimalFloatingPoint} = dec < num
+Base.:<(num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}, dec::T) where {T<:DecimalFloatingPoint} = dec > num
+Base.:(>=)(num::Union{BigFloat,Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec <= num
+Base.:(<=)(num::Union{BigFloat,Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec >= num
 
 # used for next/prevfloat:
 const pinf128 = _parse(Dec128, "+Inf")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,7 +313,7 @@ for T in (Dec32, Dec64, Dec128)
     @test T(7) / T(100) == 7//100
     @test T(7) / T(300) != 7//300
 
-    for Tf in (Float64, Float32, Float16)
+    for Tf in (BigFloat, Float64, Float32, Float16)
         @test parse(T, "0.1") != parse(Tf, "0.1")
         @test parse(Tf, "0.1") != parse(T, "0.1")
         @test parse(T, "0.7") != parse(Tf, "0.7")
@@ -492,6 +492,26 @@ end
 # issue 124
 @test parse(Complex{Dec64}, "1.0+2.0im") == Complex(d"1.0", d"2.0")
 @test parse(Dec64, SubString("1.3x", 1,3)) == d"1.3"
+
+#issue 122
+@test Dec32(π) != π
+@test Dec32(π) > π
+@test Dec32(π) >= π
+@test π != Dec32(π)
+@test π < Dec32(π)
+@test π <= Dec32(π)
+@test Dec64(π) != π
+@test Dec64(π) < π
+@test Dec64(π) <= π
+@test π != Dec64(π)
+@test π > Dec64(π)
+@test π >= Dec64(π)
+@test Dec128(π) != π
+@test Dec128(π) > π
+@test Dec128(π) >= π
+@test π != Dec128(π)
+@test π < Dec128(π)
+@test π <= Dec128(π)
 
 # issue #139
 @test convert(Dec64, big"2.5") == d"2.5"


### PR DESCRIPTION
For Irrational comparisions ==, <=, >= we are using Base functions:
==(x::Real, y::AbstractIrrational) = false
<=(x::AbstractFloat, y::AbstractIrrational) = x < y
etc

Fixes #122