### PR TITLE
Test rounding when parsing strings

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: linux - arm64 - Julia 1.3
+name: linux - arm64 - Julia 1.6
 
 platform:
   os: linux
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: Run tests
-  image: julia:1.3
+  image: julia:1.6
   commands:
   - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true)'"
   - "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.build()'"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.3"  # oldest supported version
+          - "1.6"  # oldest supported version
           - "1"    # Latest Release
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 DecFP_jll = "2.0.3"
 SpecialFunctions = "0.8, 0.9, 0.10, 0.11, 1, 2"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-DecFP_jll = "2.0.3+1"
+DecFP_jll = "2.0.3"
 SpecialFunctions = "0.8, 0.9, 0.10, 0.11, 1, 2"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+DecFP_jll = "2.0.3+1"
 SpecialFunctions = "0.8, 0.9, 0.10, 0.11, 1, 2"
 julia = "1.3"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,10 @@ for T in (Dec32, Dec64, Dec128)
     @test T("0.9999999999999999999999999999999999999999", RoundUp) == T(1)
     @test T("0.9999999999999999999999999999999999999999", RoundDown) == prevfloat(T(1))
 
+    # issue 134
+    @test T(string(DecFP._int_maxintfloat(T)), RoundUp) == maxintfloat(T)
+    @test T("1.0000000000000000000000000000000000000000", RoundUp) == T(1)
+
     @test T(0, 0, 0) == T(0)
     @test T(1, 0, 10) == T(0)
     @test isequal(T(-1, 0, 0), T(-0.0))


### PR DESCRIPTION
Test that issue #134 is fixed by DecFP_jll v2.0.3+1

The Julia requirement of v1.6 is set by the limit in DecFP_jll ([PR](https://github.com/JuliaPackaging/Yggdrasil/pull/3860/files)).

Codecov shouldn't decrease since tests were the only thing added.

Closes #134.