### PR TITLE
Drop obsolete `>` and `>=` methods

### DIFF
--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -671,17 +671,11 @@ function Base.:(==)(dec::DecimalFloatingPoint, rat::Rational)
 end
 
 Base.:(==)(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec == T(num, RoundUp) == T(num, RoundDown)
-Base.:>(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}) where {T<:DecimalFloatingPoint} = dec > T(num, RoundDown)
-Base.:<(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}) where {T<:DecimalFloatingPoint} = dec < T(num, RoundUp)
-Base.:(>=)(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec >= T(num, RoundUp)
-Base.:(<=)(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec <= T(num, RoundDown)
-
-# canonicalize comparison order:
 Base.:(==)(num::Union{BigFloat,Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec == num
-Base.:>(num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}, dec::T) where {T<:DecimalFloatingPoint} = dec < num
-Base.:<(num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}, dec::T) where {T<:DecimalFloatingPoint} = dec > num
-Base.:(>=)(num::Union{BigFloat,Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec <= num
-Base.:(<=)(num::Union{BigFloat,Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} = dec >= num
+Base.:<(num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}, dec::T) where {T<:DecimalFloatingPoint} = T(num, RoundDown) < dec
+Base.:<(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer,AbstractIrrational}) where {T<:DecimalFloatingPoint} = dec < T(num, RoundUp)
+Base.:(<=)(num::Union{BigFloat,Float16,Float32,Float64,Integer}, dec::T) where {T<:DecimalFloatingPoint} =  T(num, RoundUp) <= dec
+Base.:(<=)(dec::T, num::Union{BigFloat,Float16,Float32,Float64,Integer}) where {T<:DecimalFloatingPoint} = dec <= T(num, RoundDown)
 
 # used for next/prevfloat:
 const pinf128 = parse(Dec128, "+Inf")


### PR DESCRIPTION
These are already provided by julia base, so there is no semantical difference.

However, dropping these methods reduces the number of invalidations of loading DecFP in julia 1.12.5 from 1580 to 517. In particular, the following invalidation trees are resolved:
```
 inserting >(dec::T, num::Union{Float16, Float32, Float64, AbstractIrrational, Integer, BigFloat}) where T<:DecimalFloatingPoint @ DecFP ~/code/julia/DecFP.jl/src/DecFP.jl:674 invalidated:
   backedges: 1: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Any, ::Bool) (3 children)
              2: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Any, ::UInt64) (7 children)
              3: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Any, ::Integer) (53 children)
              4: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Any, ::Int64) (88 children)

 inserting >=(dec::T, num::Union{Float16, Float32, Float64, Integer, BigFloat}) where T<:DecimalFloatingPoint @ DecFP ~/code/julia/DecFP.jl/src/DecFP.jl:676 invalidated:
   backedges: 1: superseding >=(x, y) @ Base operators.jl:472 with MethodInstance for >=(::Number, ::Int64) (4 children)
              2: superseding >=(x, y) @ Base operators.jl:472 with MethodInstance for >=(::Any, ::Int64) (865 children)

 inserting >(num::Union{Float16, Float32, Float64, AbstractIrrational, Integer, BigFloat}, dec::T) where T<:DecimalFloatingPoint @ DecFP ~/code/julia/DecFP.jl/src/DecFP.jl:681 invalidated:
   backedges: 1: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Int64, ::Any) (1101 children)
```