### PR TITLE
Drop more `>` and `>=` methods, instead routing them through `<`/`<=`

### DIFF
--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -495,7 +495,7 @@ for w in (32,64,128)
         @eval Base.round(x::$BID, ::$r) = (flags = Ref(zero(Cuint)); @xchk(ccall(($(bidsym(w,c)), libbid), $BID, ($BID,Ref{Cuint}), x, flags), flags[], DomainError, x, mask=INVALID))
     end
 
-    for (f,c) in ((:(==),"quiet_equal"), (:>,"quiet_greater"), (:<,"quiet_less"), (:(>=), "quiet_greater_equal"), (:(<=), "quiet_less_equal"))
+    for (f,c) in ((:(==),"quiet_equal"), (:<,"quiet_less"), (:(<=), "quiet_less_equal"))
         @eval Base.$f(x::$BID, y::$BID) = ccall(($(bidsym(w,c)), libbid), Cint, ($BID,$BID,Ref{Cuint}), x, y, zero(Cuint)) != 0
     end
 


### PR DESCRIPTION
This reduces the number of invalidations of loading DecFP from 517 to 232 (with julia 1.12.5). In particular, the following invalidation trees get resolved:
```
 inserting >=(x::Dec128, y::Dec128) @ DecFP ~/code/julia/DecFP.jl/src/DecFP.jl:496 invalidated:
   backedges: 1: superseding >=(x, y) @ Base operators.jl:472 with MethodInstance for >=(::Any, ::Any) (36 children)

 inserting >(x::Dec128, y::Dec128) @ DecFP ~/code/julia/DecFP.jl/src/DecFP.jl:496 invalidated:
   backedges: 1: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Real, ::Real) (5 children)
              2: superseding >(x, y) @ Base operators.jl:425 with MethodInstance for >(::Any, ::Any) (419 children)
```